### PR TITLE
init leds

### DIFF
--- a/examples/CycleThroughColors/CycleThroughColors.ino
+++ b/examples/CycleThroughColors/CycleThroughColors.ino
@@ -16,7 +16,7 @@ ChainableLED leds(7, 8, NUM_LEDS);//defines the pin used on arduino.
 
 void setup()
 {
-  //nothing
+  leds.init();
 }
 
 float hue = 0.0;


### PR DESCRIPTION
In this example, the leds class wasn’t initiated, causing the file not to work. With `leds.init();` in the setup, it does work.
